### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gentoro MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@gentoro/mcp-nodejs-server)](https://smithery.ai/server/@gentoro/mcp-nodejs-server)
+
 MCP Server for the Gentoro services, enabling Claude to interact with Gentoro bridges and all underlying capabilities.
 
 ## Tools
@@ -42,3 +44,10 @@ Add the following to your `claude_desktop_config.json`:
 }
 ```
 
+### Installing via Smithery
+
+To install Gentoro MCP NodeJS Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@gentoro/mcp-nodejs-server):
+
+```bash
+npx -y @smithery/cli install @gentoro/mcp-nodejs-server --client claude
+```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Gentoro MCP NodeJS Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@gentoro/mcp-nodejs-server

Let me know if any tweaks have to be made!